### PR TITLE
fix: stabilize nearest quest sorting in tracker and route

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -1156,6 +1156,8 @@ function pfMap:UpdateNodes()
           if qdata and qdata.qlogid and IsQuestWatched(qdata.qlogid) then
             watched = true
           end
+          -- Route candidates are positional tuples consumed by route.lua:
+          -- { x, y, node, distance, watched, questid }.
           pfQuest.route:AddPoint({ x, y, pfMap.pins[i], nil, watched, questid })
         end
 

--- a/quest.lua
+++ b/quest.lua
@@ -44,6 +44,8 @@ end
 
 local function questAffectsCurrentZoneTracker(questid)
   local data = pfQuest.questlog and pfQuest.questlog[questid]
+  -- Current Zone mode still shows watched off-zone quests at the top, so a
+  -- collapse/expand on those quests must refresh the tracker too.
   if data and data.qlogid and IsQuestWatched(data.qlogid) then
     return true
   end

--- a/route.lua
+++ b/route.lua
@@ -206,10 +206,14 @@ local lastpos, completed = 0, 0
 local function GetQuestSortMode()
   return pfQuest_config["trackerquestsort"] == "distance" and "distance" or "level"
 end
+-- Match tracker.lua's fallback behavior so missing route distances sort last
+-- without relying on math.huge on older clients.
 local DIST_FAR = 99999999
 
 local function sortfunc(a, b)
   if pfQuest_config["trackingmethod"] == 5 then
+    -- Route tuples are { x, y, node, distance, watched, questid }
+    -- Watched quests stay ahead of all local non-watched candidates in mode 5.
     if (a[5] and 1 or -1) ~= (b[5] and 1 or -1) then
       return (a[5] and 1 or -1) > (b[5] and 1 or -1)
     end
@@ -218,6 +222,8 @@ local function sortfunc(a, b)
     local blevel = (b[3] and tonumber(b[3].qlvl)) or -1
 
     if GetQuestSortMode() == "distance" then
+      -- "Nearest" mode still keeps watched quests first; after that, prefer the
+      -- closest current-map objective and only use quest level as a tie-breaker.
       if (a[4] or DIST_FAR) ~= (b[4] or DIST_FAR) then
         return (a[4] or DIST_FAR) < (b[4] or DIST_FAR)
       end
@@ -225,6 +231,8 @@ local function sortfunc(a, b)
         return alevel > blevel
       end
     else
+      -- "Level" mode flips the middle priority: higher quest level wins first,
+      -- then distance breaks ties so the chosen target still feels local.
       if alevel ~= blevel then
         return alevel > blevel
       end
@@ -233,6 +241,8 @@ local function sortfunc(a, b)
       end
     end
 
+    -- Final stable tie-breaker so equal watched/level/distance candidates do
+    -- not reshuffle unpredictably between updates.
     local atitle = (a[3] and a[3].title) or ""
     local btitle = (b[3] and b[3].title) or ""
     if atitle ~= btitle then

--- a/route.lua
+++ b/route.lua
@@ -206,6 +206,7 @@ local lastpos, completed = 0, 0
 local function GetQuestSortMode()
   return pfQuest_config["trackerquestsort"] == "distance" and "distance" or "level"
 end
+local DIST_FAR = 99999999
 
 local function sortfunc(a, b)
   if pfQuest_config["trackingmethod"] == 5 then
@@ -217,8 +218,8 @@ local function sortfunc(a, b)
     local blevel = (b[3] and tonumber(b[3].qlvl)) or -1
 
     if GetQuestSortMode() == "distance" then
-      if (a[4] or math.huge) ~= (b[4] or math.huge) then
-        return (a[4] or math.huge) < (b[4] or math.huge)
+      if (a[4] or DIST_FAR) ~= (b[4] or DIST_FAR) then
+        return (a[4] or DIST_FAR) < (b[4] or DIST_FAR)
       end
       if alevel ~= blevel then
         return alevel > blevel
@@ -227,8 +228,8 @@ local function sortfunc(a, b)
       if alevel ~= blevel then
         return alevel > blevel
       end
-      if (a[4] or math.huge) ~= (b[4] or math.huge) then
-        return (a[4] or math.huge) < (b[4] or math.huge)
+      if (a[4] or DIST_FAR) ~= (b[4] or DIST_FAR) then
+        return (a[4] or DIST_FAR) < (b[4] or DIST_FAR)
       end
     end
 

--- a/tracker.lua
+++ b/tracker.lua
@@ -69,6 +69,8 @@ local function GetQuestSortMode()
   return pfQuest_config["trackerquestsort"] == "distance" and "distance" or "level"
 end
 
+-- Old-client Lua can misbehave with math.huge in sort fallbacks; use a plain
+-- numeric sentinel so "no distance" always sorts last without nil comparisons.
 local DIST_FAR = 99999999
 
 local function UpdateSortButton()
@@ -97,6 +99,8 @@ local function UpdateQuestDistances()
 
   local changed = nil
   local nearest = {}
+  -- Some tracker entries fall back to title keys instead of numeric questids,
+  -- so nearest-mode needs both maps to keep tracker and route ordering aligned.
   local nearestByTitle = {}
   for _, data in ipairs((pfQuest.route and pfQuest.route.coords) or {}) do
     local questid = data[6] or (data[3] and data[3].questid)

--- a/tracker.lua
+++ b/tracker.lua
@@ -69,6 +69,8 @@ local function GetQuestSortMode()
   return pfQuest_config["trackerquestsort"] == "distance" and "distance" or "level"
 end
 
+local DIST_FAR = 99999999
+
 local function UpdateSortButton()
   if not tracker or not tracker.btnsort then
     return
@@ -95,17 +97,22 @@ local function UpdateQuestDistances()
 
   local changed = nil
   local nearest = {}
+  local nearestByTitle = {}
   for _, data in ipairs((pfQuest.route and pfQuest.route.coords) or {}) do
     local questid = data[6] or (data[3] and data[3].questid)
     local distance = data[4]
     if questid and distance and (not nearest[questid] or distance < nearest[questid]) then
       nearest[questid] = distance
     end
+    local title = data[3] and data[3].title
+    if title and distance and (not nearestByTitle[title] or distance < nearestByTitle[title]) then
+      nearestByTitle[title] = distance
+    end
   end
 
   for _, button in pairs(tracker.buttons) do
     if not button.empty then
-      local distance = nearest[button.questid]
+      local distance = nearest[button.questid] or nearestByTitle[button.title]
       if button.distance ~= distance then
         button.distance = distance
         changed = true
@@ -433,12 +440,12 @@ local function trackersort(a, b)
   elseif (a.inLocalZone and 1 or -1) ~= (b.inLocalZone and 1 or -1) then
     return (a.inLocalZone and 1 or -1) > (b.inLocalZone and 1 or -1)
   elseif tracker.mode == "QUEST_TRACKING" and GetQuestSortMode() == "distance"
-         and (a.distance or math.huge) ~= (b.distance or math.huge) then
-    return (a.distance or math.huge) < (b.distance or math.huge)
+         and (a.distance or DIST_FAR) ~= (b.distance or DIST_FAR) then
+    return (a.distance or DIST_FAR) < (b.distance or DIST_FAR)
   elseif (a.level or -1) ~= (b.level or -1) then
     return (a.level or -1) > (b.level or -1)
-  elseif tracker.mode == "QUEST_TRACKING" and (a.distance or math.huge) ~= (b.distance or math.huge) then
-    return (a.distance or math.huge) < (b.distance or math.huge)
+  elseif tracker.mode == "QUEST_TRACKING" and (a.distance or DIST_FAR) ~= (b.distance or DIST_FAR) then
+    return (a.distance or DIST_FAR) < (b.distance or DIST_FAR)
   elseif (a.perc or -1) ~= (b.perc or -1) then
     return (a.perc or -1) > (b.perc or -1)
   elseif (a.title or "") ~= (b.title or "") then


### PR DESCRIPTION
The tracker and minimap/arrow path now use the same priority, and nearest sorting was hardened to avoid nil-distance crashes and mismatches.

Also added comments especially on the hard to read part.