### PR TITLE
Make quest arrow resizeable

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -345,6 +345,8 @@ function pfQuestConfig:CreateConfigEntries(config)
 
         pfUI.api.CreateBackdrop(frame.input, nil, true)
       elseif data.type == "slider" then
+        -- Copy slider-specific values out of the loop table so the callback
+        -- keeps stable bounds/config even after CreateConfigEntries continues.
         local minval = data.min
         local maxval = data.max
         local config = data.config
@@ -386,7 +388,8 @@ function pfQuestConfig:CreateConfigEntries(config)
           val = max(minval, min(maxval, val))
           val = floor(val * 10 + 0.5) / 10
 
-          -- normalize slider position to rounded value
+          -- Snap the thumb back onto the stored tenth-step so slider position,
+          -- label text, and saved config all stay visually in sync.
           this:SetValue(val)
 
           pfQuest_config[this.config] = tostring(val)
@@ -468,6 +471,8 @@ function pfQuestConfig:UpdateConfigEntries()
         local newval = tonumber(pfQuest_config[data.config]) or tonumber(data.default) or 1
         newval = floor(newval * 10 + 0.5) / 10
         local oldval = floor(configframes[data.text].input:GetValue() * 10 + 0.5) / 10
+        -- Avoid bouncing the slider callback when the UI is already showing
+        -- the same rounded value that the config stores.
         if oldval ~= newval then
           configframes[data.text].input:SetValue(newval)
         end

--- a/config.lua
+++ b/config.lua
@@ -120,6 +120,7 @@ pfQuest_defconfig = {
   { text = L["Include Quest Starters"], default = "0", type = "checkbox", config = "routestarter" },
   { text = L["Show Route On Minimap"], default = "0", type = "checkbox", config = "routeminimap" },
   { text = L["Show Arrow Along Routes"], default = "1", type = "checkbox", config = "arrow" },
+  { text = L["Arrow Scale"], default = "1.0", type = "slider", config = "arrowscale", min = 0.5, max = 3.0, step = 0.1 },
 
   { text = L["User Data"], default = nil, type = "header" },
   { text = L["Reset Configuration"], default = "1", type = "button", func = reset.config },
@@ -272,6 +273,7 @@ local maxtext = 130
 local configframes = {}
 function pfQuestConfig:CreateConfigEntries(config)
   local count = 1
+  local hasSlider = false
 
   for _, data in pairs(config) do
     if data.type then
@@ -342,6 +344,62 @@ function pfQuestConfig:CreateConfigEntries(config)
         end)
 
         pfUI.api.CreateBackdrop(frame.input, nil, true)
+      elseif data.type == "slider" then
+        local minval = data.min
+        local maxval = data.max
+        local config = data.config
+        local default = data.default
+
+        frame.input = CreateFrame("Slider", nil, frame)
+        frame.input:SetOrientation("HORIZONTAL")
+        frame.input:SetWidth(60)
+        frame.input:SetHeight(16)
+        frame.input:SetPoint("RIGHT", -20, 0)
+        frame.input:EnableMouse(true)
+        frame.input:SetMinMaxValues(minval, maxval)
+        frame.input:SetValueStep(data.step)
+        frame.input:SetThumbTexture("Interface\\BUTTONS\\WHITE8X8")
+        frame.input.thumb = frame.input:GetThumbTexture()
+        frame.input.thumb:SetHeight(14)
+        frame.input.thumb:SetWidth(8)
+        frame.input.thumb:SetTexture(0.3, 1, 0.8, 0.5)
+        pfUI.api.CreateBackdrop(frame.input, nil, true)
+
+        frame.input.config = config
+
+        -- value label to the left of the slider
+        frame.value = frame:CreateFontString(nil, "OVERLAY", "GameFontWhite")
+        frame.value:SetFont(pfUI.font_default, pfUI_config.global.font_size, "OUTLINE")
+        frame.value:SetPoint("RIGHT", frame.input, "LEFT", -4, 0)
+        frame.value:SetTextColor(0.2, 1, 0.8, 1)
+
+        local val = tonumber(pfQuest_config[config]) or tonumber(default) or 1
+        frame.input:SetValue(val)
+        frame.value:SetText(string.format("%.1fx", val))
+
+        frame.input.updating = false
+        frame.input:SetScript("OnValueChanged", function()
+          if this.updating then return end
+          this.updating = true
+
+          local val = this:GetValue()
+          val = max(minval, min(maxval, val))
+          val = floor(val * 10 + 0.5) / 10
+
+          -- normalize slider position to rounded value
+          this:SetValue(val)
+
+          pfQuest_config[this.config] = tostring(val)
+          frame.value:SetText(string.format("%.1fx", val))
+
+          if pfQuest and pfQuest.route and pfQuest.route.arrow then
+            pfQuest.route.arrow:ApplyScale()
+          end
+
+          this.updating = false
+        end)
+
+        hasSlider = true
       elseif data.type == "button" and data.func then
         frame.input = CreateFrame("Button", nil, frame)
         frame.input:SetWidth(32)
@@ -356,7 +414,7 @@ function pfQuestConfig:CreateConfigEntries(config)
       end
 
       -- increase size and zoom back due to blizzard backdrop reasons...
-      if frame.input and pfUI.api.emulated then
+      if frame.input and pfUI.api.emulated and data.type ~= "slider" then
         frame.input:SetWidth(frame.input:GetWidth() / 0.6)
         frame.input:SetHeight(frame.input:GetHeight() / 0.6)
         frame.input:SetScale(0.8)
@@ -370,7 +428,7 @@ function pfQuestConfig:CreateConfigEntries(config)
   end
 
   -- update sizes / positions
-  width = maxtext + 100
+  width = maxtext + (hasSlider and 140 or 100)
   local column, row = 1, 0
 
   for _, data in pairs(config) do
@@ -406,6 +464,13 @@ function pfQuestConfig:UpdateConfigEntries()
         configframes[data.text].input:SetChecked((pfQuest_config[data.config] == "1" and true or nil))
       elseif data.type == "text" then
         configframes[data.text].input:SetText(pfQuest_config[data.config])
+      elseif data.type == "slider" then
+        local newval = tonumber(pfQuest_config[data.config]) or tonumber(data.default) or 1
+        newval = floor(newval * 10 + 0.5) / 10
+        local oldval = floor(configframes[data.text].input:GetValue() * 10 + 0.5) / 10
+        if oldval ~= newval then
+          configframes[data.text].input:SetValue(newval)
+        end
       end
     end
   end
@@ -434,6 +499,10 @@ pfQuestConfig:SetScript("OnEvent", function()
 
     if pfBrowserIcon and pfQuest_config["minimapbutton"] == "0" then
       pfBrowserIcon:Hide()
+    end
+
+    if pfQuest and pfQuest.route and pfQuest.route.arrow then
+      pfQuest.route.arrow:ApplyScale()
     end
   end
 end)

--- a/route.lua
+++ b/route.lua
@@ -642,6 +642,10 @@ pfQuest.route.arrow.hitframe:SetAllPoints(pfQuest.route.arrow.content)
 pfQuest.route.arrow.hitframe:EnableMouseWheel(true)
 
 pfQuest.route.arrow.hitframe:SetScript("OnMouseWheel", function()
+  if not IsShiftKeyDown() then
+    return
+  end
+
   local current = tonumber(pfQuest_config["arrowscale"]) or 1
   if arg1 > 0 then
     current = current + 0.1

--- a/route.lua
+++ b/route.lua
@@ -589,3 +589,68 @@ pfQuest.route.arrow.distance:SetTextColor(0.8, 0.8, 0.8)
 pfQuest.route.arrow.distance:SetJustifyH("CENTER")
 
 pfQuest.route.arrow.parent = pfQuest.route
+
+-- arrow scale method: single source of truth for both scroll wheel and config slider
+function pfQuest.route.arrow:ApplyScale()
+  local scale = tonumber(pfQuest_config["arrowscale"]) or 1
+  scale = max(0.5, min(3.0, scale))
+  scale = floor(scale * 10 + 0.5) / 10
+  pfQuest_config["arrowscale"] = tostring(scale)
+  self:SetScale(scale)
+end
+
+-- scale indicator: brief "1.5x" flash on scroll
+pfQuest.route.arrow.scaletext = pfQuest.route.arrow:CreateFontString(nil, "OVERLAY", "GameFontWhite")
+pfQuest.route.arrow.scaletext:SetPoint("BOTTOMRIGHT", pfQuest.route.arrow, "BOTTOMRIGHT", -2, 2)
+pfQuest.route.arrow.scaletext:SetFont(pfUI.font_default, pfUI_config.global.font_size, "OUTLINE")
+pfQuest.route.arrow.scaletext:SetJustifyH("RIGHT")
+pfQuest.route.arrow.scaletext:SetTextColor(1, 1, 1, 1)
+pfQuest.route.arrow.scaletext:Hide()
+
+pfQuest.route.arrow.scalefader = CreateFrame("Frame", nil, pfQuest.route.arrow)
+pfQuest.route.arrow.scalefader:Hide()
+pfQuest.route.arrow.scalefader:SetScript("OnUpdate", function()
+  local elapsed = GetTime() - this.fadetime
+  if elapsed > 1.5 then
+    pfQuest.route.arrow.scaletext:Hide()
+    this:Hide()
+    return
+  end
+  local alpha = 1.0 - (elapsed / 1.5)
+  pfQuest.route.arrow.scaletext:SetAlpha(alpha)
+end)
+
+local function ShowScaleIndicator(val)
+  pfQuest.route.arrow.scaletext:SetText(string.format("%.1fx", val))
+  pfQuest.route.arrow.scaletext:SetAlpha(1)
+  pfQuest.route.arrow.scaletext:Show()
+  pfQuest.route.arrow.scalefader.fadetime = GetTime()
+  pfQuest.route.arrow.scalefader:Show()
+end
+
+-- hit frame: extends wheel-responsive area to cover text below the arrow
+-- only EnableMouseWheel, not EnableMouse, so clicks/drags pass through
+pfQuest.route.arrow.hitframe = CreateFrame("Frame", nil, pfQuest.route.arrow)
+pfQuest.route.arrow.hitframe:SetPoint("TOPLEFT", 0, 0)
+pfQuest.route.arrow.hitframe:SetPoint("TOPRIGHT", 0, 0)
+pfQuest.route.arrow.hitframe:SetHeight(100)
+pfQuest.route.arrow.hitframe:EnableMouseWheel(true)
+
+pfQuest.route.arrow.hitframe:SetScript("OnMouseWheel", function()
+  local current = tonumber(pfQuest_config["arrowscale"]) or 1
+  if arg1 > 0 then
+    current = current + 0.1
+  else
+    current = current - 0.1
+  end
+  current = max(0.5, min(3.0, current))
+  current = floor(current * 10 + 0.5) / 10
+  pfQuest_config["arrowscale"] = tostring(current)
+  pfQuest.route.arrow:ApplyScale()
+  ShowScaleIndicator(current)
+
+  -- sync config slider if visible
+  if pfQuestConfig:IsShown() then
+    pfQuestConfig:UpdateConfigEntries()
+  end
+end)

--- a/route.lua
+++ b/route.lua
@@ -560,29 +560,36 @@ pfQuest.route.arrow:SetScript("OnUpdate", function()
   this.model:SetAlpha(alpha)
 end)
 
-pfQuest.route.arrow.texture = pfQuest.route.arrow:CreateTexture("pfQuestRouteNodeTexture", "OVERLAY")
-pfQuest.route.arrow.texture:SetWidth(28)
-pfQuest.route.arrow.texture:SetHeight(28)
-pfQuest.route.arrow.texture:SetPoint("BOTTOM", 0, 0)
+-- Keep the outer arrow frame as the stable drag/anchor box and scale a child container instead
+pfQuest.route.arrow.content = CreateFrame("Frame", nil, pfQuest.route.arrow)
+pfQuest.route.arrow.content:SetPoint("TOPLEFT", pfQuest.route.arrow, "TOPLEFT", -80, 0)
+pfQuest.route.arrow.content:SetPoint("BOTTOMRIGHT", pfQuest.route.arrow, "BOTTOMRIGHT", 80, -54)
 
-pfQuest.route.arrow.model = pfQuest.route.arrow:CreateTexture("pfQuestRouteArrow", "MEDIUM")
+pfQuest.route.arrow.model = pfQuest.route.arrow.content:CreateTexture("pfQuestRouteArrow", "MEDIUM")
 pfQuest.route.arrow.model:SetTexture(pfQuestConfig.path .. "\\img\\arrow")
 pfQuest.route.arrow.model:SetTexCoord(0, 0, 0.109375, 0.08203125)
-pfQuest.route.arrow.model:SetAllPoints()
+pfQuest.route.arrow.model:SetWidth(48)
+pfQuest.route.arrow.model:SetHeight(36)
+pfQuest.route.arrow.model:SetPoint("TOP", pfQuest.route.arrow.content, "TOP", 0, 0)
 
-pfQuest.route.arrow.title = pfQuest.route.arrow:CreateFontString("pfQuestRouteText", "HIGH", "GameFontWhite")
+pfQuest.route.arrow.texture = pfQuest.route.arrow.content:CreateTexture("pfQuestRouteNodeTexture", "OVERLAY")
+pfQuest.route.arrow.texture:SetWidth(28)
+pfQuest.route.arrow.texture:SetHeight(28)
+pfQuest.route.arrow.texture:SetPoint("BOTTOM", pfQuest.route.arrow.model, "BOTTOM", 0, 0)
+
+pfQuest.route.arrow.title = pfQuest.route.arrow.content:CreateFontString("pfQuestRouteText", "HIGH", "GameFontWhite")
 pfQuest.route.arrow.title:SetPoint("TOP", pfQuest.route.arrow.model, "BOTTOM", 0, -10)
 pfQuest.route.arrow.title:SetFont(pfUI.font_default, pfUI_config.global.font_size + 1, "OUTLINE")
 pfQuest.route.arrow.title:SetTextColor(1, 0.8, 0)
 pfQuest.route.arrow.title:SetJustifyH("CENTER")
 
-pfQuest.route.arrow.description = pfQuest.route.arrow:CreateFontString("pfQuestRouteText", "HIGH", "GameFontWhite")
+pfQuest.route.arrow.description = pfQuest.route.arrow.content:CreateFontString("pfQuestRouteText", "HIGH", "GameFontWhite")
 pfQuest.route.arrow.description:SetPoint("TOP", pfQuest.route.arrow.title, "BOTTOM", 0, -2)
 pfQuest.route.arrow.description:SetFont(pfUI.font_default, pfUI_config.global.font_size, "OUTLINE")
 pfQuest.route.arrow.description:SetTextColor(1, 1, 1)
 pfQuest.route.arrow.description:SetJustifyH("CENTER")
 
-pfQuest.route.arrow.distance = pfQuest.route.arrow:CreateFontString("pfQuestRouteDistance", "HIGH", "GameFontWhite")
+pfQuest.route.arrow.distance = pfQuest.route.arrow.content:CreateFontString("pfQuestRouteDistance", "HIGH", "GameFontWhite")
 pfQuest.route.arrow.distance:SetPoint("TOP", pfQuest.route.arrow.description, "BOTTOM", 0, -2)
 pfQuest.route.arrow.distance:SetFont(pfUI.font_default, pfUI_config.global.font_size - 1, "OUTLINE")
 pfQuest.route.arrow.distance:SetTextColor(0.8, 0.8, 0.8)
@@ -596,18 +603,18 @@ function pfQuest.route.arrow:ApplyScale()
   scale = max(0.5, min(3.0, scale))
   scale = floor(scale * 10 + 0.5) / 10
   pfQuest_config["arrowscale"] = tostring(scale)
-  self:SetScale(scale)
+  self.content:SetScale(scale)
 end
 
 -- scale indicator: brief "1.5x" flash on scroll
-pfQuest.route.arrow.scaletext = pfQuest.route.arrow:CreateFontString(nil, "OVERLAY", "GameFontWhite")
-pfQuest.route.arrow.scaletext:SetPoint("BOTTOMRIGHT", pfQuest.route.arrow, "BOTTOMRIGHT", -2, 2)
+pfQuest.route.arrow.scaletext = pfQuest.route.arrow.content:CreateFontString(nil, "OVERLAY", "GameFontWhite")
+pfQuest.route.arrow.scaletext:SetPoint("BOTTOMRIGHT", pfQuest.route.arrow.model, "BOTTOMRIGHT", -2, 2)
 pfQuest.route.arrow.scaletext:SetFont(pfUI.font_default, pfUI_config.global.font_size, "OUTLINE")
 pfQuest.route.arrow.scaletext:SetJustifyH("RIGHT")
 pfQuest.route.arrow.scaletext:SetTextColor(1, 1, 1, 1)
 pfQuest.route.arrow.scaletext:Hide()
 
-pfQuest.route.arrow.scalefader = CreateFrame("Frame", nil, pfQuest.route.arrow)
+pfQuest.route.arrow.scalefader = CreateFrame("Frame", nil, pfQuest.route.arrow.content)
 pfQuest.route.arrow.scalefader:Hide()
 pfQuest.route.arrow.scalefader:SetScript("OnUpdate", function()
   local elapsed = GetTime() - this.fadetime
@@ -628,12 +635,10 @@ local function ShowScaleIndicator(val)
   pfQuest.route.arrow.scalefader:Show()
 end
 
--- hit frame: extends wheel-responsive area to cover text below the arrow
--- only EnableMouseWheel, not EnableMouse, so clicks/drags pass through
-pfQuest.route.arrow.hitframe = CreateFrame("Frame", nil, pfQuest.route.arrow)
-pfQuest.route.arrow.hitframe:SetPoint("TOPLEFT", 0, 0)
-pfQuest.route.arrow.hitframe:SetPoint("TOPRIGHT", 0, 0)
-pfQuest.route.arrow.hitframe:SetHeight(100)
+-- Extend wheel capture across the whole visible arrow block, including the
+-- text below the model, without stealing click/drag input from the parent.
+pfQuest.route.arrow.hitframe = CreateFrame("Frame", nil, pfQuest.route.arrow.content)
+pfQuest.route.arrow.hitframe:SetAllPoints(pfQuest.route.arrow.content)
 pfQuest.route.arrow.hitframe:EnableMouseWheel(true)
 
 pfQuest.route.arrow.hitframe:SetScript("OnMouseWheel", function()


### PR DESCRIPTION
Made quest arrows resizeable through shift + scrollwheel. It will flash the current scale for a brief moment

Also added a slider in /db config
<details>
<img width="782" height="440" alt="image" src="https://github.com/user-attachments/assets/4a5f1b42-04c7-49a9-8a35-959a4b2afdb6" />

<img width="2866" height="1788" alt="image" src="https://github.com/user-attachments/assets/5a6d84ec-7166-4b3e-9a2a-6b1705f48621" />
</details>