### PR TITLE
Fix intermittent quest priority flicker and persist arrow settings

### DIFF
--- a/route.lua
+++ b/route.lua
@@ -447,6 +447,19 @@ end)
 
 pfQuest.route.arrow:SetScript("OnDragStop", function()
   this:StopMovingOrSizing()
+  local anchor, x, y = pfUI.api.ConvertFrameAnchor(this, pfUI.api.GetBestAnchor(this))
+  this:ClearAllPoints()
+  this:SetPoint(anchor, x, y)
+
+  -- save position
+  pfQuest_config.arrowpos = { anchor, x, y }
+end)
+
+pfQuest.route.arrow:SetScript("OnShow", function()
+  if pfQuest_config.arrowpos then
+    this:ClearAllPoints()
+    this:SetPoint(unpack(pfQuest_config.arrowpos))
+  end
 end)
 
 local invalid, lasttarget

--- a/route.lua
+++ b/route.lua
@@ -160,6 +160,10 @@ pfQuest.route.Reset = function(self)
   self.lastDrawX = nil
   self.lastDrawY = nil
   self.lastDrawNode = nil
+  self.tick = nil
+  self.throttle = nil
+  self.recalculate = nil
+  self.refreshTrackerDistances = true
 end
 
 pfQuest.route.AddPoint = function(self, tbl)
@@ -312,6 +316,11 @@ pfQuest.route:SetScript("OnUpdate", function()
     end
 
     this.recalculate = GetTime() + 1
+
+    if this.refreshTrackerDistances and tracker and tracker.RefreshNearestDistances then
+      tracker:RefreshNearestDistances()
+      this.refreshTrackerDistances = nil
+    end
   end
 
   -- show arrow when route exists and is stable

--- a/tracker.lua
+++ b/tracker.lua
@@ -226,6 +226,19 @@ tracker.buttons = {}
 tracker.buttonByTitle = {} -- reverse map: title → button index, for O(1) duplicate detection
 tracker.mode = "QUEST_TRACKING"
 
+function tracker.RefreshNearestDistances()
+  if tracker.mode ~= "QUEST_TRACKING" or GetQuestSortMode() ~= "distance" then
+    return
+  end
+
+  tracker.distanceTick = GetTime() + 0.2
+  UpdateQuestDistances()
+
+  if tracker.needsSort then
+    tracker.DoLayout()
+  end
+end
+
 tracker.backdrop = CreateFrame("Frame", nil, tracker)
 tracker.backdrop:SetAllPoints(tracker)
 tracker.backdrop.bg = tracker.backdrop:CreateTexture(nil, "BACKGROUND")


### PR DESCRIPTION
Clears stale route timing state whenever UpdateNodes() rebuilds route candidates, so the arrow no longer briefly uses insertion-order targets before nearest sorting catches up. After the first post-rebuild distance recompute and sort, the tracker refreshes nearest-mode distances immediately, removing the short window where it could momentarily rank a farther quest above a nearer one. 
The arrow now also persists both its scale and screen position across reloads by restoring the saved arrowscale and arrowpos settings from pfQuest_config.