### PR TITLE
keep pfQuest icon size constant during world map zoom

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -56,6 +56,9 @@ controlkey:SetScript("OnUpdate", function()
   end
 end)
 
+local mainmap_base_effective_scale = nil
+local mainmap_inversescale = 1.0
+
 local validmaps = setmetatable({}, { __mode = "kv" })
 local rgbcache = setmetatable({}, { __mode = "kv" })
 local minimap_sizes = pfDB["minimap"]
@@ -1072,11 +1075,28 @@ function pfMap:UpdateNode(frame, node, color, obj, distance)
     frame:SetScript("OnClick", (frame.func or pfMap.NodeClick))
   end
 
+  pfMap:ResizeNode(frame, obj)
+
+  frame.node = node
+end
+
+function pfMap:ResizeNode(frame, obj)
   local highlight = frame.texture and pfMap.highlightdb[frame][pfMap.highlight] and true or nil
   local target = frame.texture and pfQuest.route and pfQuest.route.IsTarget(frame) or nil
 
   -- set default sizes for different node types
   frame.defsize = (frame.cluster or frame.layer == 4) and 18 or 14
+
+  -- Adjust node size if main map is zoomed in/out
+  if (obj ~= "minimap") then
+    if (frame.title and pfQuest.icons[frame.title]) or frame.icon then
+      -- Adjust for icons being 1 unit smaller than their parent frame
+      -- Looks better to keep the icon size constant even if the frame grows a bit.
+      frame.defsize = (frame.defsize - 2) * (mainmap_inversescale) + 2
+    else
+      frame.defsize = frame.defsize * mainmap_inversescale
+    end
+  end
 
   -- make the current route target visible
   if target then
@@ -1090,8 +1110,16 @@ function pfMap:UpdateNode(frame, node, color, obj, distance)
     frame:SetWidth(frame.defsize)
     frame:SetHeight(frame.defsize)
   end
+end
 
-  frame.node = node
+function pfMap:ResizeNodes()
+  if pfMap.pins then
+    for i = 1, table.getn(pfMap.pins) do
+      if pfMap.pins[i]:IsShown() then
+        pfMap:ResizeNode(pfMap.pins[i])
+      end
+    end
+  end
 end
 
 function pfMap:UpdateNodes()
@@ -1540,3 +1568,25 @@ if compat.client >= 30300 then
     end
   end
 end
+
+-- Resize icons on map zoom change
+function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
+  if not mainmap_base_effective_scale then
+    mainmap_base_effective_scale = WorldMapButton:GetEffectiveScale()
+  end
+  hookedfunction(frame, scale)
+  local new_inversescale = mainmap_base_effective_scale / WorldMapButton:GetEffectiveScale()
+  if (mainmap_inversescale ~= new_inversescale) then
+    mainmap_inversescale = new_inversescale
+    pfMap:ResizeNodes()
+  end
+end
+-- Listen for WorldMapFrame scale changes
+local pfHookWorldMapFrame_SetScale = WorldMapFrame.SetScale
+WorldMapFrame.SetScale = function(frame, scale) pfMap:OnMapScaleChanged(frame, scale, pfHookWorldMapFrame_SetScale) end
+-- Listen for WorldMapDetailFrame scale changes
+local pfHookWorldMapDetailFrame_SetScale = WorldMapDetailFrame.SetScale
+WorldMapDetailFrame.SetScale = function(frame, scale) pfMap:OnMapScaleChanged(frame, scale, pfHookWorldMapDetailFrame_SetScale) end
+-- Listen for WorldMapButton scale changes
+local pfHookWorldMapButton_SetScale = WorldMapButton.SetScale
+WorldMapButton.SetScale = function(frame, scale) pfMap:OnMapScaleChanged(frame, scale, pfHookWorldMapButton_SetScale) end

--- a/map.lua
+++ b/map.lua
@@ -1571,10 +1571,10 @@ end
 
 -- Resize icons on map zoom change
 function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
+  hookedfunction(frame, scale)  -- apply the scale first
   if not mainmap_base_effective_scale then
     mainmap_base_effective_scale = WorldMapButton:GetEffectiveScale()
   end
-  hookedfunction(frame, scale)
   local new_inversescale = mainmap_base_effective_scale / WorldMapButton:GetEffectiveScale()
   if (mainmap_inversescale ~= new_inversescale) then
     mainmap_inversescale = new_inversescale

--- a/map.lua
+++ b/map.lua
@@ -1571,11 +1571,12 @@ end
 
 -- Resize icons on map zoom change
 function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
-  hookedfunction(frame, scale)  -- apply the scale first
   if not mainmap_base_effective_scale then
-    mainmap_base_effective_scale = WorldMapButton:GetEffectiveScale()
+    mainmap_base_effective_scale = WorldMapButton:GetEffectiveScale() / WorldMapFrame:GetScale()
   end
-  local new_inversescale = mainmap_base_effective_scale / WorldMapButton:GetEffectiveScale()
+  hookedfunction(frame, scale)
+  local zoom_scale = WorldMapButton:GetEffectiveScale() / WorldMapFrame:GetScale()
+  local new_inversescale = mainmap_base_effective_scale / zoom_scale
   if (mainmap_inversescale ~= new_inversescale) then
     mainmap_inversescale = new_inversescale
     pfMap:ResizeNodes()


### PR DESCRIPTION
Hook WorldMapFrame/WorldMapDetailFrame/WorldMapButton SetScale to detect zoom changes from addons like Magnify, and rescale node sizes to maintain consistent screen appearance. Uses relative effective-scale ratio to avoid overcorrection on non-default UI scale setups.

<img width="1000" height="542" alt="image" src="https://github.com/user-attachments/assets/bdc79f06-8607-4825-bfb1-331c7e80a2ee" />


Credits to @BlacRyu for the initial fix, and @copypasteonly for feedback.