### PR TITLE
perf: resolve questlog entries via O(1) title index (fix multi-second quest-accept freeze)

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -493,6 +493,13 @@ pfDatabase.lastQuestGiversSet = {}
 -- Covers: wrong race, wrong class, missing loc name.
 pfDatabase.staticRejectSet = {}
 
+-- Index of exact quest title -> { id, id, ... }. Lets GetQuestIDs resolve a
+-- questlog entry to its DB id in O(1) instead of scanning the whole quest
+-- table on every questlog entry (the source of the quest-accept hang).
+-- Rebuilt by BuildStaticRejectSet (same PLAYER_ENTERING_WORLD / locale-swap
+-- timing), so it always reflects the merged base+turtle quest tables.
+pfDatabase.questTitleIndex = {}
+
 function pfDatabase:BuildNameIndex()
   local idx = self.nameIndex
   -- clear existing index in-place
@@ -533,6 +540,12 @@ function pfDatabase:BuildStaticRejectSet()
     reject[id] = nil
   end
 
+  -- (re)build the quest title -> ids index in the same pass.
+  local titleIndex = self.questTitleIndex
+  for t in pairs(titleIndex) do
+    titleIndex[t] = nil
+  end
+
   -- UnitRace/UnitClass may return nil before PLAYER_ENTERING_WORLD.
   -- In that case skip race/class checks; BuildNameIndex is called again
   -- from the locale-detection OnUpdate after login, which will populate them.
@@ -542,8 +555,20 @@ function pfDatabase:BuildStaticRejectSet()
   local pclass = class and pfDatabase:GetBitByClass(class) or nil
 
   for id in pairs(quests) do
+    local loc = pfDB.quests.loc[id]
+    local title = loc and loc.T
+
+    -- index by exact title (every named quest, regardless of reject state, so
+    -- candidate lookups match the old full-table scan behaviour exactly)
+    if title then
+      if not titleIndex[title] then
+        titleIndex[title] = {}
+      end
+      insert(titleIndex[title], id)
+    end
+
     -- missing loc name
-    if not pfDB.quests.loc[id] or not pfDB.quests.loc[id].T then
+    if not title then
       reject[id] = true
 
     -- wrong race (only when prace is known)
@@ -2039,13 +2064,10 @@ function pfDatabase:GetQuestIDs(qid)
   local best = 0
   local results = {}
 
-  local tcount = 0
-  -- check if multiple quests share the same name
-  for id, data in pairs(pfDB["quests"]["loc"]) do
-    if quests[id] and data.T == title then
-      tcount = tcount + 1
-    end
-  end
+  -- O(1) candidate lookup via the prebuilt title index instead of scanning the
+  -- entire quest table on every questlog entry (the source of the accept hang).
+  local candidates = pfDatabase.questTitleIndex[title]
+  local tcount = candidates and getn(candidates) or 0
 
   -- no title was found, run levenshtein on titles
   if tcount == 0 and title then
@@ -2072,15 +2094,17 @@ function pfDatabase:GetQuestIDs(qid)
         return pfQuest_questcache[identifier]
       end
     else
-      -- set title to best result
+      -- set title to best result and refresh candidates for the matched title
       title = ttitle
+      candidates = pfDatabase.questTitleIndex[title]
     end
   end
 
-  for id, data in pairs(pfDB["quests"]["loc"]) do
+  for _, id in pairs(candidates or {}) do
+    local data = pfDB["quests"]["loc"][id]
     local score = 0
 
-    if quests[id] and data.T and data.T == title then
+    if quests[id] and data and data.T == title then
       -- low score for same name
       score = 1
 


### PR DESCRIPTION
## Problem

Accepting a quest causes a multi-second client freeze on 1.12 / TurtleWoW clients with the large Turtle DB (~11k quests), and it scales with how full your quest log is.

Root cause is in `pfDatabase:GetQuestIDs()`:

- On 1.12 `GetQuestLink` does not exist, so the fast "ask the client for the quest id" path is always skipped.
- The fallback resolves a questlog entry to its DB id by **scanning the entire `pfDB.quests.loc` table twice** — once to count same-title quests (`tcount`), once to score candidates.
- `pfQuest:UpdateQuestlog()` calls `GetQuestIDs()` for **every** entry in the quest log on each `QUEST_LOG_UPDATE`. Accepting one quest re-resolves the whole log, so the cost is `O(quests_in_log × all_quests)`.

With the TurtleWoW DB this is a visible **1–2s hang on every quest accept**.

### Measurements (Capycraft / Turtle 1.18.1 client, `/pfquest debug`)

| | before | after |
|---|---|---|
| `Update QuestLog` on a cache-miss accept | **0.314s** per uncached quest | **~0.000s** |
| `SearchQuests` / `SearchQuestID` | already ~0 | unchanged |

The fan-out across a full log (each entry re-resolved) is what pushed this into the 1–2s range; the debug output showed every quest in the log being reprocessed on a single accept.

## Fix

Build a `title -> { id, ... }` index once in `BuildStaticRejectSet()` — it already iterates the full merged quest table at `PLAYER_ENTERING_WORLD` and on locale swaps, so the index always tracks the merged base+turtle tables with no extra pass and correct invalidation.

`GetQuestIDs()` then:
- gets `tcount` and the candidate list via an **O(1)** index lookup instead of a full scan,
- scores only the **same-titled candidates** instead of iterating all ~11k entries.

The levenshtein fuzzy fallback (for titles genuinely absent from the DB) is left intact; it now only runs for unknown quests and caches its result as before.

## Behaviour

No functional change to resolution results — same scoring, same cache, same fuzzy fallback. Only the candidate enumeration is indexed. Verified on a live Capycraft/Turtle 1.18.1 install: freeze gone, quest ids resolve identically.

Parser-checked with `luac -p`.