### PR TITLE
fix: guard FormatQuestText against nil/non-string input

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -1990,6 +1990,9 @@ function pfDatabase:AddCustomIcon(id, img, root)
 end
 
 function pfDatabase:FormatQuestText(questText)
+  -- guard against nil/non-string input: quests with no objective ("O") or
+  -- description ("D") in the DB pass nil here, and string.gsub would error.
+  if type(questText) ~= "string" then return "" end
   questText = string.gsub(questText, "$[Nn]", UnitName("player"))
   questText = string.gsub(questText, "$[Cc]", strlower(UnitClass("player")))
   questText = string.gsub(questText, "$[Rr]", strlower(UnitRace("player")))


### PR DESCRIPTION
## Problem

`pfDatabase:GetQuestIDs()` scores same-titled candidates by comparing quest text via `FormatQuestText()`:

```lua
score = score + max(24 - lev(pfDatabase:FormatQuestText(pfDB.quests.loc[id]["O"]), objective, 24), 0)
score = score + max(24 - lev(pfDatabase:FormatQuestText(pfDB.quests.loc[id]["D"]), text, 24), 0)
```

Quests with no objective (`O`) or description (`D`) in the DB pass `nil` into `FormatQuestText`, where `string.gsub(nil, ...)` raises a Lua error and aborts quest resolution.

## Fix

Return `""` for non-string input:

```lua
function pfDatabase:FormatQuestText(questText)
  if type(questText) ~= "string" then return "" end
  ...
```

One-line guard, no behaviour change for valid strings. Parser-checked with `luac -p`. Found in the wild on a Capycraft/Turtle 1.18.1 client.