### PR TITLE
Updated GetQuestIDs function for SuperWoW compatibility

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -2003,13 +2003,11 @@ end
 -- Try to guess the quest ID based on the questlog ID
 -- Returns possible quest IDs
 function pfDatabase:GetQuestIDs(qid)
-  if GetQuestLink then
-    local questLink = GetQuestLink(qid)
-    if questLink then
-      local _, _, id = strfind(questLink, "|c.*|Hquest:([%d]+):([-]?[%d]+)|h%[(.*)%]|h|r")
-      if id then
-        return { [1] = tonumber(id) }
-      end
+
+  if GetQuestID then -- SuperWoW compatibility with GetQuestLink & GetQuestID functions
+    local questID = GetQuestID(qid)
+    if questID then
+		return { [1] = questID }
     end
   end
 


### PR DESCRIPTION
SuperWoW 2.1 breaks PfQuest due to it having vestiges of 2.4.3 function checks
This pull request stops the game from checking for 2.4.3 function GetQuestLink and also makes it use the more performant and accurate SuperWoW function GetQuestID if found