### PR TITLE
Fix: Minimap extreme zoom crash + coordinate parsing

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -980,26 +980,28 @@ function pfDatabase:SearchAreaTriggerID(id, meta, maps, prio)
   local prio = prio or 1
 
   for _, data in pairs(areatrigger[id]["coords"]) do
-    local x, y, zone = unpack(data)
-
-    if zone and zone > 0 then
-      -- add all gathered data
-      meta = meta or {}
-      meta["spawn"] = pfQuest_Loc["Exploration Mark"]
-      meta["spawnid"] = id
-      meta["item"] = nil
-
-      meta["title"] = meta["quest"] or meta["item"] or meta["spawn"]
-      meta["zone"] = zone
-      meta["x"] = x
-      meta["y"] = y
-
-      meta["level"] = pfQuest_Loc["N/A"]
-      meta["spawntype"] = pfQuest_Loc["Trigger"]
-      meta["respawn"] = pfQuest_Loc["N/A"]
-
-      maps[zone] = maps[zone] and maps[zone] + prio or prio
-      pfMap:AddNode(meta)
+    if type(data) == "table" then
+      local x, y, zone = unpack(data)
+  
+      if zone and zone > 0 then
+        -- add all gathered data
+        meta = meta or {}
+        meta["spawn"] = pfQuest_Loc["Exploration Mark"]
+        meta["spawnid"] = id
+        meta["item"] = nil
+  
+        meta["title"] = meta["quest"] or meta["item"] or meta["spawn"]
+        meta["zone"] = zone
+        meta["x"] = x
+        meta["y"] = y
+  
+        meta["level"] = pfQuest_Loc["N/A"]
+        meta["spawntype"] = pfQuest_Loc["Trigger"]
+        meta["respawn"] = pfQuest_Loc["N/A"]
+  
+        maps[zone] = maps[zone] and maps[zone] + prio or prio
+        pfMap:AddNode(meta)
+      end
     end
   end
 
@@ -1030,16 +1032,18 @@ function pfDatabase:SearchMobID(id, meta, maps, prio)
   meta["description"] = pfDatabase:BuildQuestDescription(meta)
 
   for _, data in pairs(units[id]["coords"]) do
-    local x, y, zone, respawn = unpack(data)
-
-    if zone > 0 then
-      meta["zone"] = zone
-      meta["x"] = x
-      meta["y"] = y
-      meta["respawn"] = respawn > 0 and SecondsToTime(respawn)
-
-      maps[zone] = maps[zone] and maps[zone] + prio or prio
-      pfMap:AddNode(meta)
+    if type(data) == "table" then
+      local x, y, zone, respawn = unpack(data)
+  
+      if zone > 0 then
+        meta["zone"] = zone
+        meta["x"] = x
+        meta["y"] = y
+        meta["respawn"] = respawn > 0 and SecondsToTime(respawn)
+  
+        maps[zone] = maps[zone] and maps[zone] + prio or prio
+        pfMap:AddNode(meta)
+      end
     end
   end
 
@@ -1285,16 +1289,18 @@ function pfDatabase:SearchObjectID(id, meta, maps, prio)
   meta["description"] = pfDatabase:BuildQuestDescription(meta)
 
   for _, data in pairs(objects[id]["coords"]) do
-    local x, y, zone, respawn = unpack(data)
-
-    if zone > 0 then
-      meta["zone"] = zone
-      meta["x"] = x
-      meta["y"] = y
-      meta["respawn"] = respawn and SecondsToTime(respawn)
-
-      maps[zone] = maps[zone] and maps[zone] + prio or prio
-      pfMap:AddNode(meta)
+    if type(data) == "table" then
+      local x, y, zone, respawn = unpack(data)
+  
+      if zone > 0 then
+        meta["zone"] = zone
+        meta["x"] = x
+        meta["y"] = y
+        meta["respawn"] = respawn and SecondsToTime(respawn)
+  
+        maps[zone] = maps[zone] and maps[zone] + prio or prio
+        pfMap:AddNode(meta)
+      end
     end
   end
 

--- a/map.lua
+++ b/map.lua
@@ -1571,15 +1571,31 @@ end
 
 -- Resize icons on map zoom change
 function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
-  if not mainmap_base_effective_scale then
-    mainmap_base_effective_scale = WorldMapButton:GetEffectiveScale() / WorldMapFrame:GetScale()
+  local mapScale = WorldMapFrame:GetScale()
+  local btnScale = WorldMapButton:GetEffectiveScale()
+  
+  if not mainmap_base_effective_scale and mapScale and mapScale > 0 and btnScale and btnScale > 0 then
+    mainmap_base_effective_scale = btnScale / mapScale
   end
+  
   hookedfunction(frame, scale)
-  local zoom_scale = WorldMapButton:GetEffectiveScale() / WorldMapFrame:GetScale()
-  local new_inversescale = mainmap_base_effective_scale / zoom_scale
-  if (mainmap_inversescale ~= new_inversescale) then
-    mainmap_inversescale = new_inversescale
-    pfMap:ResizeNodes()
+  
+  if not mainmap_base_effective_scale then return end
+  
+  local newMapScale = WorldMapFrame:GetScale()
+  local newBtnScale = WorldMapButton:GetEffectiveScale()
+  
+  if newMapScale and newMapScale > 0 and newBtnScale and newBtnScale > 0 then
+    local zoom_scale = newBtnScale / newMapScale
+    if zoom_scale > 0 then
+      local new_inversescale = mainmap_base_effective_scale / zoom_scale
+      if new_inversescale > 10 then new_inversescale = 10 end
+      if new_inversescale < 0.1 then new_inversescale = 0.1 end
+      if (mainmap_inversescale ~= new_inversescale) then
+        mainmap_inversescale = new_inversescale
+        pfMap:ResizeNodes()
+      end
+    end
   end
 end
 -- Listen for WorldMapFrame scale changes


### PR DESCRIPTION
When using max or min zoom, client would crash trying to divide by nil val. Added guardrails against that, especialy annoying bug as it would crash whole client. 
Added guardrails for parsing coordinates, Turtle module comes with malformed tables for certain zones, additional conditon allows it to fail without crashing the whole addon.