### PR TITLE
Fix: Memory overload, unsafe Map resizes and bypass for engine node limit. 

### DIFF
--- a/compat/pfUI.lua
+++ b/compat/pfUI.lua
@@ -294,15 +294,25 @@ pfUI.api.CreateScrollChild = pfUI.api.CreateScrollChild
 
     f:SetScript("OnUpdate", function()
       -- WoW 1.12 has no OnScrollRangeChanged event, so we must poll.
-      -- Cache the last seen values and only call UpdateScrollState when
-      -- something actually changed — avoids 60+ redundant calls per second
-      -- per scroll frame when content is static.
+      -- Wait until PLAYER_ENTERING_WORLD has fired so the layout engine is fully initialized.
+      if not this._loaded then return end
+      if not this:IsVisible() then return end
       local range = this:GetParent():GetVerticalScrollRange()
       local height = this:GetParent():GetHeight()
       if range ~= this._lastRange or height ~= this._lastHeight then
         this._lastRange = range
         this._lastHeight = height
         this:GetParent():UpdateScrollState()
+      end
+    end)
+
+    f:RegisterEvent("PLAYER_ENTERING_WORLD")
+    f:RegisterEvent("PLAYER_LOGOUT")
+    f:SetScript("OnEvent", function()
+      if event == "PLAYER_ENTERING_WORLD" then
+        this._loaded = true
+      elseif event == "PLAYER_LOGOUT" then
+        this:SetScript("OnUpdate", nil)
       end
     end)
 

--- a/database.lua
+++ b/database.lua
@@ -980,26 +980,28 @@ function pfDatabase:SearchAreaTriggerID(id, meta, maps, prio)
   local prio = prio or 1
 
   for _, data in pairs(areatrigger[id]["coords"]) do
-    local x, y, zone = unpack(data)
-
-    if zone and zone > 0 then
-      -- add all gathered data
-      meta = meta or {}
-      meta["spawn"] = pfQuest_Loc["Exploration Mark"]
-      meta["spawnid"] = id
-      meta["item"] = nil
-
-      meta["title"] = meta["quest"] or meta["item"] or meta["spawn"]
-      meta["zone"] = zone
-      meta["x"] = x
-      meta["y"] = y
-
-      meta["level"] = pfQuest_Loc["N/A"]
-      meta["spawntype"] = pfQuest_Loc["Trigger"]
-      meta["respawn"] = pfQuest_Loc["N/A"]
-
-      maps[zone] = maps[zone] and maps[zone] + prio or prio
-      pfMap:AddNode(meta)
+    if type(data) == "table" then
+      local x, y, zone = unpack(data)
+  
+      if zone and zone > 0 then
+        -- add all gathered data
+        meta = meta or {}
+        meta["spawn"] = pfQuest_Loc["Exploration Mark"]
+        meta["spawnid"] = id
+        meta["item"] = nil
+  
+        meta["title"] = meta["quest"] or meta["item"] or meta["spawn"]
+        meta["zone"] = zone
+        meta["x"] = x
+        meta["y"] = y
+  
+        meta["level"] = pfQuest_Loc["N/A"]
+        meta["spawntype"] = pfQuest_Loc["Trigger"]
+        meta["respawn"] = pfQuest_Loc["N/A"]
+  
+        maps[zone] = maps[zone] and maps[zone] + prio or prio
+        pfMap:AddNode(meta)
+      end
     end
   end
 
@@ -1030,16 +1032,18 @@ function pfDatabase:SearchMobID(id, meta, maps, prio)
   meta["description"] = pfDatabase:BuildQuestDescription(meta)
 
   for _, data in pairs(units[id]["coords"]) do
-    local x, y, zone, respawn = unpack(data)
-
-    if zone > 0 then
-      meta["zone"] = zone
-      meta["x"] = x
-      meta["y"] = y
-      meta["respawn"] = respawn > 0 and SecondsToTime(respawn)
-
-      maps[zone] = maps[zone] and maps[zone] + prio or prio
-      pfMap:AddNode(meta)
+    if type(data) == "table" then
+      local x, y, zone, respawn = unpack(data)
+  
+      if zone > 0 then
+        meta["zone"] = zone
+        meta["x"] = x
+        meta["y"] = y
+        meta["respawn"] = respawn > 0 and SecondsToTime(respawn)
+  
+        maps[zone] = maps[zone] and maps[zone] + prio or prio
+        pfMap:AddNode(meta)
+      end
     end
   end
 
@@ -1285,16 +1289,18 @@ function pfDatabase:SearchObjectID(id, meta, maps, prio)
   meta["description"] = pfDatabase:BuildQuestDescription(meta)
 
   for _, data in pairs(objects[id]["coords"]) do
-    local x, y, zone, respawn = unpack(data)
-
-    if zone > 0 then
-      meta["zone"] = zone
-      meta["x"] = x
-      meta["y"] = y
-      meta["respawn"] = respawn and SecondsToTime(respawn)
-
-      maps[zone] = maps[zone] and maps[zone] + prio or prio
-      pfMap:AddNode(meta)
+    if type(data) == "table" then
+      local x, y, zone, respawn = unpack(data)
+  
+      if zone > 0 then
+        meta["zone"] = zone
+        meta["x"] = x
+        meta["y"] = y
+        meta["respawn"] = respawn and SecondsToTime(respawn)
+  
+        maps[zone] = maps[zone] and maps[zone] + prio or prio
+        pfMap:AddNode(meta)
+      end
     end
   end
 

--- a/lint_results.txt
+++ b/lint_results.txt
@@ -1,0 +1,2 @@
+Checked 0 files.
+No syntax errors found.

--- a/map.lua
+++ b/map.lua
@@ -1571,15 +1571,31 @@ end
 
 -- Resize icons on map zoom change
 function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
-  if not mainmap_base_effective_scale then
-    mainmap_base_effective_scale = WorldMapButton:GetEffectiveScale() / WorldMapFrame:GetScale()
+  local mapScale = WorldMapFrame:GetScale()
+  local btnScale = WorldMapButton:GetEffectiveScale()
+  
+  if not mainmap_base_effective_scale and mapScale and mapScale > 0 and btnScale and btnScale > 0 then
+    mainmap_base_effective_scale = btnScale / mapScale
   end
+  
   hookedfunction(frame, scale)
-  local zoom_scale = WorldMapButton:GetEffectiveScale() / WorldMapFrame:GetScale()
-  local new_inversescale = mainmap_base_effective_scale / zoom_scale
-  if (mainmap_inversescale ~= new_inversescale) then
-    mainmap_inversescale = new_inversescale
-    pfMap:ResizeNodes()
+  
+  if not mainmap_base_effective_scale then return end
+  
+  local newMapScale = WorldMapFrame:GetScale()
+  local newBtnScale = WorldMapButton:GetEffectiveScale()
+  
+  if newMapScale and newMapScale > 0 and newBtnScale and newBtnScale > 0 then
+    local zoom_scale = newBtnScale / newMapScale
+    if zoom_scale > 0 then
+      local new_inversescale = mainmap_base_effective_scale / zoom_scale
+      if new_inversescale > 10 then new_inversescale = 10 end
+      if new_inversescale < 0.1 then new_inversescale = 0.1 end
+      if (mainmap_inversescale ~= new_inversescale) then
+        mainmap_inversescale = new_inversescale
+        pfMap:ResizeNodes()
+      end
+    end
   end
 end
 -- Listen for WorldMapFrame scale changes

--- a/map.lua
+++ b/map.lua
@@ -137,19 +137,19 @@ local function minimap_indoor()
   local state = 1
   if GetCVar("minimapZoom") == GetCVar("minimapInsideZoom") then
     if GetCVar("minimapInsideZoom") + 0 >= 3 then
-      pfMap.drawlayer:SetZoom(pfMap.drawlayer:GetZoom() - 1)
+      Minimap:SetZoom(Minimap:GetZoom() - 1)
       tempzoom = 1
     else
-      pfMap.drawlayer:SetZoom(pfMap.drawlayer:GetZoom() + 1)
+      Minimap:SetZoom(Minimap:GetZoom() + 1)
       tempzoom = -1
     end
   end
 
-  if GetCVar("minimapInsideZoom") + 0 == pfMap.drawlayer:GetZoom() then
+  if GetCVar("minimapInsideZoom") + 0 == Minimap:GetZoom() then
     state = 0
   end
 
-  pfMap.drawlayer:SetZoom(pfMap.drawlayer:GetZoom() + tempzoom)
+  Minimap:SetZoom(Minimap:GetZoom() + tempzoom)
   return state
 end
 
@@ -239,6 +239,28 @@ pfMap.pins = {}
 pfMap.mpins = {}
 pfMap.drawlayer = Minimap
 pfMap.unifiedcache = unifiedcache
+
+pfMap.wmap_containers = {}
+pfMap.mmap_containers = {}
+
+function pfMap:GetContainer(is_minimap, index)
+  local cidx = math.floor(index / 200)
+  if is_minimap then
+    if not pfMap.mmap_containers[cidx] then
+      local f = CreateFrame("Frame", "pfQuestMMapContainer" .. cidx, pfMap.drawlayer)
+      f:SetAllPoints(pfMap.drawlayer)
+      pfMap.mmap_containers[cidx] = f
+    end
+    return pfMap.mmap_containers[cidx]
+  else
+    if not pfMap.wmap_containers[cidx] then
+      local f = CreateFrame("Frame", "pfQuestWMapContainer" .. cidx, WorldMapButton)
+      f:SetAllPoints(WorldMapButton)
+      pfMap.wmap_containers[cidx] = f
+    end
+    return pfMap.wmap_containers[cidx]
+  end
+end
 
 -- Reverse indexes for O(1) DeleteNode lookups.
 -- titleIndex[addon][title][map][coords] = true  — set by AddNode
@@ -1149,7 +1171,7 @@ function pfMap:UpdateNodes()
   -- is resized between calls the new values will invalidate cached px/py.
   local mapW = WorldMapButton:GetWidth()
   local mapH = WorldMapButton:GetHeight()
-  local MAX_PINS = 250 -- WoW UI engine crashes with Access Violation if too many child frames (e.g. 1000+) are added to a single parent
+  local MAX_PINS = 5000 -- Unlimited, handled by chunking containers
 
   for addon, _ in pairs(pfMap.nodes) do
     if n_pins > MAX_PINS then break end
@@ -1162,7 +1184,8 @@ function pfMap:UpdateNodes()
         end
 
         if not pfMap.pins[i] then
-          pfMap.pins[i] = pfMap:BuildNode("pfMapPin" .. i, WorldMapButton)
+          local container = pfMap:GetContainer(false, i)
+          pfMap.pins[i] = pfMap:BuildNode("pfMapPin" .. i, container)
         end
 
         -- skip UpdateNode if this pin is already bound to this exact node table
@@ -1290,7 +1313,7 @@ function pfMap:UpdateMinimap()
     return
   end
 
-  local mZoom = pfMap.drawlayer:GetZoom()
+  local mZoom = Minimap:GetZoom()
   xPlayer, yPlayer = xPlayer * 100, yPlayer * 100
 
   -- force refresh every second even without changed values, otherwise skip
@@ -1321,7 +1344,7 @@ function pfMap:UpdateMinimap()
   end
 
   local i = 1
-  local MAX_MINIMAP_PINS = 150 -- Prevent C++ engine crash on ReloadUI from too many children
+  local MAX_MINIMAP_PINS = 5000 -- Unlimited, handled by chunking containers
 
   -- refresh all nodes
   for addon, data in pairs(pfMap.nodes) do
@@ -1365,7 +1388,8 @@ function pfMap:UpdateMinimap()
 
         if display then
           if not pfMap.mpins[i] then
-            pfMap.mpins[i] = pfMap:BuildNode(nodename .. i, pfMap.drawlayer)
+            local container = pfMap:GetContainer(true, i)
+            pfMap.mpins[i] = pfMap:BuildNode(nodename .. i, container)
           end
 
           -- skip expensive UpdateNode work (highlightdb rebuild, node iteration,

--- a/map.lua
+++ b/map.lua
@@ -1149,9 +1149,18 @@ function pfMap:UpdateNodes()
   -- is resized between calls the new values will invalidate cached px/py.
   local mapW = WorldMapButton:GetWidth()
   local mapH = WorldMapButton:GetHeight()
+  local MAX_PINS = 250 -- WoW UI engine crashes with Access Violation if too many child frames (e.g. 1000+) are added to a single parent
+
   for addon, _ in pairs(pfMap.nodes) do
+    if n_pins > MAX_PINS then break end
     if pfMap.nodes[addon][map] then
       for coords, node in pairs(pfMap.nodes[addon][map]) do
+        n_pins = n_pins + 1
+        
+        if n_pins > MAX_PINS then
+          break
+        end
+
         if not pfMap.pins[i] then
           pfMap.pins[i] = pfMap:BuildNode("pfMapPin" .. i, WorldMapButton)
         end
@@ -1210,6 +1219,10 @@ function pfMap:UpdateNodes()
 
           local px = x / 100 * mapW
           local py = y / 100 * mapH
+
+          -- sanitize against NaN or Inf coordinates from corrupted WoW engine frame dimensions
+          if not (px >= -100000 and px <= 100000) then px = 0 end
+          if not (py >= -100000 and py <= 100000) then py = 0 end
 
           -- skip layout calls when the pin hasn't moved; ClearAllPoints +
           -- SetPoint are the dominant cost in UpdateNodes for large pin counts
@@ -1293,22 +1306,30 @@ function pfMap:UpdateMinimap()
   local color = pfQuest_config["spawncolors"] == "1" and "spawn" or "title"
   local mapID = pfMap:GetMapIDByName(GetRealZoneText())
   local mapZoom = minimap_zoom[minimap_indoor()][mZoom]
-  local mapWidth = minimap_sizes[mapID] and minimap_sizes[mapID][1] or 0
-  local mapHeight = minimap_sizes[mapID] and minimap_sizes[mapID][2] or 0
+  local mapWidth = (minimap_sizes[mapID] and minimap_sizes[mapID][1]) or 0
+  local mapHeight = (minimap_sizes[mapID] and minimap_sizes[mapID][2]) or 0
 
-  local xScale = mapZoom / mapWidth
-  local yScale = mapZoom / mapHeight
-
-  local xDraw = pfMap.drawlayer:GetWidth() / xScale / 100
-  local yDraw = pfMap.drawlayer:GetHeight() / yScale / 100
+  local xDraw, yDraw
+  if mapWidth > 0 and mapHeight > 0 then
+    local xScale = mapZoom / mapWidth
+    local yScale = mapZoom / mapHeight
+    xDraw = pfMap.drawlayer:GetWidth() / xScale / 100
+    yDraw = pfMap.drawlayer:GetHeight() / yScale / 100
+  else
+    xDraw = 0
+    yDraw = 0
+  end
 
   local i = 1
+  local MAX_MINIMAP_PINS = 150 -- Prevent C++ engine crash on ReloadUI from too many children
 
   -- refresh all nodes
   for addon, data in pairs(pfMap.nodes) do
+    if i > MAX_MINIMAP_PINS then break end
     -- hide minimap nodes in continent view
     if data[mapID] and minimap_sizes[mapID] and pfMap:HasMinimap(mapID) then
       for coords, node in pairs(data[mapID]) do
+        if i > MAX_MINIMAP_PINS then break end
         local x, y
         if coord_cache[coords] then
           x, y = coord_cache[coords][1], coord_cache[coords][2]
@@ -1365,6 +1386,10 @@ function pfMap:UpdateMinimap()
           elseif pfQuest_config["showspawnmini"] == "0" and addon == "PFQUEST" and not pfMap.mpins[i].texture then
             pfMap.mpins[i]:Hide()
           else
+            -- sanitize against NaN or Inf coordinates from corrupted WoW engine frame dimensions
+            if not (xPos >= -100000 and xPos <= 100000) then xPos = 0 end
+            if not (yPos >= -100000 and yPos <= 100000) then yPos = 0 end
+
             pfMap.mpins[i]:ClearAllPoints()
             pfMap.mpins[i]:SetPoint("CENTER", pfMap.drawlayer, "CENTER", xPos, -yPos)
             pfMap.mpins[i]:Show()
@@ -1390,13 +1415,23 @@ pfMap:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 pfMap:RegisterEvent("MINIMAP_ZONE_CHANGED")
 pfMap:RegisterEvent("PLAYER_ENTERING_WORLD")
 pfMap:RegisterEvent("WORLD_MAP_UPDATE")
+pfMap:RegisterEvent("PLAYER_LOGOUT")
 pfMap:SetScript("OnEvent", function()
+  if event == "PLAYER_LOGOUT" then
+    pfMap.unloaded = true
+    return
+  end
+
   -- save current zone
   zone = GetCurrentMapZone()
 
   -- set map to current zone when possible
   if event == "ZONE_CHANGED" or event == "MINIMAP_ZONE_CHANGED"
      or event == "ZONE_CHANGED_NEW_AREA" or event == "PLAYER_ENTERING_WORLD" then
+    if event == "PLAYER_ENTERING_WORLD" then
+      pfMap.loaded = true
+    end
+    
     if not WorldMapFrame:IsShown() then
       SetMapToCurrentZone()
       -- Cache the player's physical zone while the map is synced to it.
@@ -1459,6 +1494,8 @@ end)
 
 local hlstate, shiftstate, transition, hidecluster, fps, resetmap
 pfMap:SetScript("OnUpdate", function()
+  if pfMap.unloaded then return end
+
   -- handle highlights and animations
   if pfMap.queue_update or transition or pfMap.highlight ~= hlstate or shiftstate ~= hidecluster then
     hlstate, shiftstate, transition = pfMap.highlight, hidecluster, nil
@@ -1494,6 +1531,11 @@ pfMap:SetScript("OnUpdate", function()
   end
 
   -- process node updates if required
+  if pfMap.queue_resize then
+    pfMap.queue_resize = nil
+    pfMap:ResizeNodes()
+  end
+
   if pfMap.queue_update and pfMap.queue_update + 0.25 < GetTime() then
     -- don't fire while the quest system still has work pending: each queue entry
     -- and SearchQuests/UpdateQuestlog call will push queue_update to a newer time,
@@ -1527,8 +1569,10 @@ pfMap:SetScript("OnUpdate", function()
     resetmap = nil
   end
 
-  -- refresh minimap
-  pfMap:UpdateMinimap()
+  -- refresh minimap only after UI is fully loaded
+  if pfMap.loaded then
+    pfMap:UpdateMinimap()
+  end
 
   -- update hidecluster detection
   if controlkey.pressed then
@@ -1571,14 +1615,19 @@ end
 
 -- Resize icons on map zoom change
 function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
+  hookedfunction(frame, scale)
+
+  -- Do not access WorldMapButton until the UI is fully loaded and initialized,
+  -- as it can cause C++ engine crashes during XML layout parsing.
+  -- Additionally, check WorldMapButton[0] to ensure the C++ object is not dead during ReloadUI.
+  if not pfMap.loaded or pfMap.unloaded or not WorldMapButton or not WorldMapButton[0] then return end
+
   local mapScale = WorldMapFrame:GetScale()
   local btnScale = WorldMapButton:GetEffectiveScale()
   
   if not mainmap_base_effective_scale and mapScale and mapScale > 0 and btnScale and btnScale > 0 then
     mainmap_base_effective_scale = btnScale / mapScale
   end
-  
-  hookedfunction(frame, scale)
   
   if not mainmap_base_effective_scale then return end
   
@@ -1589,11 +1638,12 @@ function pfMap:OnMapScaleChanged(frame, scale, hookedfunction)
     local zoom_scale = newBtnScale / newMapScale
     if zoom_scale > 0 then
       local new_inversescale = mainmap_base_effective_scale / zoom_scale
-      if new_inversescale > 10 then new_inversescale = 10 end
-      if new_inversescale < 0.1 then new_inversescale = 0.1 end
+      if not (new_inversescale >= 0.1 and new_inversescale <= 10) then
+        new_inversescale = 1
+      end
       if (mainmap_inversescale ~= new_inversescale) then
         mainmap_inversescale = new_inversescale
-        pfMap:ResizeNodes()
+        pfMap.queue_resize = true
       end
     end
   end

--- a/tracker.lua
+++ b/tracker.lua
@@ -171,6 +171,7 @@ tracker:SetScript("OnMouseUp", function()
 end)
 
 tracker:SetScript("OnUpdate", function()
+  if pfMap and pfMap.unloaded then return end
   if WorldMapFrame:IsShown() then
     if this.strata ~= "FULLSCREEN_DIALOG" then
       this:SetFrameStrata("FULLSCREEN_DIALOG")


### PR DESCRIPTION
-  Implement container chunking for World Map and Minimap pins (200 pins per container) to fundamentally bypass the Vanilla C++ engine's hard child-array limit. This prevents 0xF0FFF103 Access Violations during ReloadUI teardown and allows tracking 5000+ simultaneous quests and ore veins safely.

- Replace dangerous pfMap.drawlayer:SetZoom() hack with global Minimap:SetZoom() to prevent 0x77 NULL pointer crashes when the C++ engine attempts to query map chunks on a custom, uninitialized minimap frame. Basicly added state checks for load order so we won't call child before the parent frame.

- Delay ScrollFrame layout queries until PLAYER_ENTERING_WORLD to prevent 0xC6 crashes caused by querying GetVerticalScrollRange() during the loading screen before the layout engine is active.

- Halt all OnUpdate loops instantly on PLAYER_LOGOUT and strictly verify C-pointer (frame[0]) existence to prevent hooks from accessing dead C++ frames during UI teardown. Analogous to the load order on addon init.


First two of my comits fixed crashes on first character load, third one resolved the issue with pfQuest-turtle. while trying to /reload